### PR TITLE
fix: add a role to appKey fields

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -50,7 +50,8 @@
       ]
     },
     "appKey": {
-      "type": "text"
+      "type": "text",
+      "role": "identifier"
     },
     "appSecret": {
       "type": "password"

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ async function start(fields) {
 }
 
 async function getBillsListAndTestTokens(ovh) {
-  return await ovh.requestPromised('GET', '/me/bill').catch(function(e) {
+  return await ovh.requestPromised('GET', '/me/bill').catch(function (e) {
     if (e.error == undefined || e.message == undefined) {
       throw e
     } else {
@@ -67,7 +67,7 @@ async function getBillsListAndTestTokens(ovh) {
 async function getBillDetails(ovh, billId) {
   return await ovh
     .requestPromised('GET', `/me/bill/${billId}`)
-    .catch(function(e) {
+    .catch(function (e) {
       if (
         e.error &&
         e.error == 403 &&


### PR DESCRIPTION
To avoid an error in harvest when related to a vault

In this cas, harvest tends to take "advancedFields" as identifier field. Another fix will be added in harvest to have at least a proper error in this case, better than "p[y] is undefined"
